### PR TITLE
Use "Public Domain" license for split_sequence

### DIFF
--- a/split_sequence/package.xml
+++ b/split_sequence/package.xml
@@ -11,7 +11,7 @@
   <maintainer email="moesenle@cs.tum.edu">Lorenz Moesenlechner</maintainer>
   <maintainer email="georg.bartels@cs.uni-bremen.de">Georg Bartels</maintainer>
 
-  <license></license>
+  <license>Public Domain</license>
 
   <url type="website">http://www.cliki.net/SPLIT-SEQUENCE</url>
   <url type="bugtracker">https://github.com/cram-code/cram_core/issues</url>


### PR DESCRIPTION
Please do not use an empty license tag.
