### PR TITLE
Creates a makefile to update libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,22 +10,31 @@ lisp_unit = https://github.com/OdonataResearchLLC/lisp-unit.git
 split_sequence = https://github.com/sharplispers/split-sequence.git
 trivial_features = https://github.com/trivial-features/trivial-features.git
 trivial_garbage = https://github.com/trivial-garbage/trivial-garbage.git
-trivial_gray_stream = https://github.com/trivial-gray-streams/trivial-gray-streams.git
+trivial_gray_streams = https://github.com/trivial-gray-streams/trivial-gray-streams.git
 yason = https://github.com/hanshuebner/yason.git
 
 usage:
-		@echo "Usage: make update PKG=<pkgname>"
+		@echo "Usage: make update PKG=<pkgname> [VERSION=<version>]"
 		@echo "================================"
 		@echo "<pkgname> may be one of: alexandria babel cffi cl_store cl_utilities fiveam gsd"
 		@echo "                         gsll lisp_unit split_sequence trivial_features"
 		@echo "                         trivial_garbage trivial_gray_stream yason"
+		@echo "<version> may be a commit hash, a tag or a branch name"
 
-update:
+clone_repo:
 		@rm -r ./$(PKG)/src
 		@echo "Cloning repository $($(PKG))..."
 		@git clone $($(PKG)) ./$(PKG)/src
-		$(eval GIT_VERSION := $(shell cd ./$(PKG)/src; git rev-parse HEAD))
-		@echo "Updating version hash..."
-		@sed -i '/<!--external-version>.*<\/external-version-->/ s/>.*</>$(GIT_VERSION)</g' ./$(PKG)/package.xml
+
+set_version: clone_repo
+ifneq ($(VERSION),)
+		$(shell cd ./$(PKG)/src; git checkout $(VERSION) --)
+else
+		$(eval VERSION := $(shell cd ./$(PKG)/src; git rev-parse HEAD))
+endif
+		@echo "Updating version..."
+		@sed -i '/<!--external-version>.*<\/external-version-->/ s/>.*</>$(VERSION)</g' ./$(PKG)/package.xml
+
+update: set_version
 		@rm -rf ./$(PKG)/src/.{git,gitignore}
 		@echo "Done."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+alexandria = git://common-lisp.net/projects/alexandria/alexandria.git
+babel = https://github.com/cl-babel/babel.git
+cffi = https://github.com/cffi/cffi.git
+cl_store = https://github.com/skypher/cl-store.git
+cl_utilities = https://github.com/Publitechs/cl-utilities.git
+fiveam = https://github.com/sionescu/fiveam.git
+gsd = http://repo.or.cz/gsd.git
+gsll = git://repo.or.cz/gsll.git
+lisp_unit = https://github.com/OdonataResearchLLC/lisp-unit.git
+split_sequence = https://github.com/sharplispers/split-sequence.git
+trivial_features = https://github.com/trivial-features/trivial-features.git
+trivial_garbage = https://github.com/trivial-garbage/trivial-garbage.git
+trivial_gray_stream = https://github.com/trivial-gray-streams/trivial-gray-streams.git
+yason = https://github.com/hanshuebner/yason.git
+
+usage:
+		@echo "Usage: make update PKG=<pkgname>"
+		@echo "================================"
+		@echo "<pkgname> may be one of: alexandria babel cffi cl_store cl_utilities fiveam gsd"
+		@echo "                         gsll lisp_unit split_sequence trivial_features"
+		@echo "                         trivial_garbage trivial_gray_stream yason"
+
+update:
+		@rm -r ./$(PKG)/src
+		@echo "Cloning repository $($(PKG))..."
+		@git clone $($(PKG)) ./$(PKG)/src
+		$(eval GIT_VERSION := $(shell cd ./$(PKG)/src; git rev-parse HEAD))
+		@echo "Updating version hash..."
+		@sed -i '/<!--external-version>.*<\/external-version-->/ s/>.*</>$(GIT_VERSION)</g' ./$(PKG)/package.xml
+		@rm -rf ./$(PKG)/src/.{git,gitignore}
+		@echo "Done."


### PR DESCRIPTION
This PR adds a Makefile to easily update 3rd party libraries.

It is invokable via `make update PKG=<pkgname>`. It includes a simple usage information that is shown when just `make` or `make usage` is run.

Basically it pulls the repository for the library and removes the .git directory and the .gitignore file.

It does not commit anything or creates a branch (yet, I don't know if this feature is wanted or not).

It also updates the external-version information in the package.xml file. This feature is still a bit fragile (white space sensitive).
